### PR TITLE
Update to V0.11 Testnet Relaunch

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "google-protobuf": "3.7.0-rc.2",
     "grpc-web": "1.0.6",
     "ngx-captcha": "6.2.1",
+    "node-sass": "^4.13.1",
     "rxjs": "6.4.0",
     "tslib": "1.9.3",
     "websocket": "1.0.28",

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -9,13 +9,15 @@ import { ethers } from 'ethers';
 })
 export class HomeComponent {
   readonly testnetProperties = [
-    'Full, Casper Proof of Stake',
+    'Casper Proof of Stake',
     'Goerli Testnet ETH for Staking',
+    'Same Configuration Parameters as Mainnet'
   ];
 
   readonly notTestnetProperties = [
     'Includes Smart Contract & EVM Functionality',
     'Real ETH',
+    'Sharding or Cross-Shard Transactions'
   ];
 
   readonly DEPOSIT_AMOUNT = ethers.utils.formatEther(environment.depositAmount);

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -9,17 +9,13 @@ import { ethers } from 'ethers';
 })
 export class HomeComponent {
   readonly testnetProperties = [
-    'Prysm Only, Single Client Testnet',
     'Full, Casper Proof of Stake',
     'Goerli Testnet ETH for Staking',
-    'Publicly Accessible',
   ];
 
   readonly notTestnetProperties = [
-    'Multi-Client Network',
     'Includes Smart Contract & EVM Functionality',
     'Real ETH',
-    'Highly Optimized',
   ];
 
   readonly DEPOSIT_AMOUNT = ethers.utils.formatEther(environment.depositAmount);

--- a/src/app/pages/participate/participate.component.html
+++ b/src/app/pages/participate/participate.component.html
@@ -37,7 +37,7 @@
       attestations in the beacon chain and shard chains.
     </p>
     <div>
-      The easiest way to get Prysm is to use our installation script in our repository: <a href="https://github.com/prysmaticlabs/prysm" target="_blank">github.com/prysmaticlabs/prysm</a>. First, clone our repo and navigate to it. We'll be using the installation script in the next sections.
+      The easiest way to get Prysm is to use our installation script in our repository: <a href="https://github.com/prysmaticlabs/prysm" target="_blank">github.com/prysmaticlabs/prysm</a>. First, clone our repository and navigate to it. We'll be using an installation script contained in the repository for the next sections.
       <pre>
 git clone https://github.com/prysmaticlabs/prysm && cd ./prysm
 </pre>
@@ -91,7 +91,7 @@ git clone https://github.com/prysmaticlabs/prysm && cd ./prysm
       <ng-template matStepLabel>Generate a validator public / private key</ng-template>
       <div>
         <pre>
-   ./prysm.sh validator accounts create --keystore-path=/data --password=changeme</pre>
+   ./prysm.sh validator accounts create --keystore-path=$HOME/validator --password=changeme</pre>
        <div>
          From those results, copy and paste the deposit data below.
        </div>

--- a/src/app/pages/participate/participate.component.html
+++ b/src/app/pages/participate/participate.component.html
@@ -37,10 +37,10 @@
       attestations in the beacon chain and shard chains.
     </p>
     <div>
-      The easiest way to get Prysm is to use the docker images.
+      The easiest way to get Prysm is to use our installation script in our repository: <a href="https://github.com/prysmaticlabs/prysm" target="_blank">github.com/prysmaticlabs/prysm</a>. First, clone our repo and navigate to it. We'll be using the installation script in the next sections.
       <pre>
-docker pull gcr.io/prysmaticlabs/prysm/validator:{{DOCKER_TAG}}
-docker pull gcr.io/prysmaticlabs/prysm/beacon-chain:{{DOCKER_TAG}}</pre>
+git clone https://github.com/prysmaticlabs/prysm && cd ./prysm
+</pre>
     </div>
     <div>
       Alternatively, you can install Prysm by following our docs <a href="https://docs.prylabs.network/docs/getting-started.html" target="_blank">here 💎</a>
@@ -91,9 +91,7 @@ docker pull gcr.io/prysmaticlabs/prysm/beacon-chain:{{DOCKER_TAG}}</pre>
       <ng-template matStepLabel>Generate a validator public / private key</ng-template>
       <div>
         <pre>
-docker run -it -v $HOME/prysm:/data \
-   gcr.io/prysmaticlabs/prysm/validator:{{DOCKER_TAG}} \
-   accounts create --keystore-path=/data --password=changeme</pre>
+   ./prysm.sh validator accounts create --keystore-path=/data --password=changeme</pre>
        <div>
          From those results, copy and paste the deposit data below.
        </div>
@@ -121,19 +119,12 @@ docker run -it -v $HOME/prysm:/data \
     <ng-template matStepLabel>Start your beacon chain & validator clients</ng-template>
     <span>You'll need two terminals for this step.</span>
     <pre>
-docker run -it -v $HOME/prysm:/data -p 4000:4000 \
-  gcr.io/prysmaticlabs/prysm/beacon-chain:{{DOCKER_TAG}} \
-  --datadir=/data
+      ./prysm.sh beacon-chain
     </pre>
 
     <span>Run the next command in another terminal.</span>
     <pre>
-docker run -it -v $HOME/prysm:/data --network="host" \
-  gcr.io/prysmaticlabs/prysm/validator:{{DOCKER_TAG}} \
-  --beacon-rpc-provider=127.0.0.1:4000 \
-  --keystore-path=/data \
-  --datadir=/data \
-  --password=changeme
+      ./prysm.sh validator --password=changeme
   </pre>
   </mat-step>
 
@@ -155,8 +146,9 @@ docker run -it -v $HOME/prysm:/data --network="host" \
   <mat-step>
     <ng-template matStepLabel>Wait for your validator assignment</ng-template>
     <div>
-      Now, once your validator is up and running - you just have to wait for its activation! It will take about 10 minutes, as there is a voting period in which
-      new deposits are added to the running chain from other validators. In the mainnet configuration, this process takes about 2 hours. Once you get assigned,
+      Now, once your validator is up and running - you just have to wait for its activation! This process takes about 2 hours. 
+      You can follow the current beacon chain in Bitfly's block explorer: <a href="https://beaconcha.in" target="_blank">https://beaconcha.in</a> or on <a href="https://beacon.etherscan.io" target="_blank">https://beacon.etherscan.io</a>
+      <br/>Once you get assigned,
       you'll be able to see how your validator performs its responsibility of creating or voting on blocks as well as earning any rewards throughout its lifecycle.
       Your beacon chain client must be synced for the validator assignment to be seen by your validator client.
       If you leave your validator offline for a while, it will begin to accrue penalties from the network for being idle. Wanna learn more about Prysm and the

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,5 +2,5 @@ export const environment = {
   production: true,
   recaptchaSiteKey: '6Lf78pEUAAAAAH4kEmwj-Q9GAT7ILmBFJGSOKkHq',
   apiEndpoint: 'https://api.prylabs.net',
-  depositAmount: '3200000000000000000', // 3.2 ETH
+  depositAmount: '32000000000000000000', // 32 ETH
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,7 +6,7 @@ export const environment = {
   production: false,
   recaptchaSiteKey: '6Lf78pEUAAAAAH4kEmwj-Q9GAT7ILmBFJGSOKkHq',
   apiEndpoint: 'https://api.prylabs.net',
-  depositAmount: '3200000000000000000', // 3.2 ETH
+  depositAmount: '32000000000000000000', // 32 ETH
 };
 
 /*

--- a/yarn.lock
+++ b/yarn.lock
@@ -5556,7 +5556,7 @@ lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5,
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@^4.17.13:
+lodash@^4.17.13, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -6021,6 +6021,11 @@ nan@2.13.2, nan@^2.10.0, nan@^2.11.0, nan@^2.12.1, nan@^2.2.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
   integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
 
+nan@^2.13.2:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -6184,6 +6189,29 @@ node-sass@4.11.0:
     meow "^3.7.0"
     mkdirp "^0.5.1"
     nan "^2.10.0"
+    node-gyp "^3.8.0"
+    npmlog "^4.0.0"
+    request "^2.88.0"
+    sass-graph "^2.2.4"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
+
+node-sass@^4.13.1:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
+  integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash "^4.17.15"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.13.2"
     node-gyp "^3.8.0"
     npmlog "^4.0.0"
     request "^2.88.0"


### PR DESCRIPTION
This PR modifies all instances of 3.2 ETH to 32 ETH and overall modifies the language of the site to align with our new testnet relaunch. It also recommends installing Prysm using the new ./prysm.sh script instead of docker.