### PR TITLE
Skip participate steps if user already has Prysm

### DIFF
--- a/src/app/pages/participate/participate.component.html
+++ b/src/app/pages/participate/participate.component.html
@@ -22,7 +22,7 @@
     <mat-icon>check</mat-icon>
   </ng-template>
 
-  <mat-step>
+  <mat-step *ngIf="!hasPrysm">
     <ng-template matStepLabel>Get Prysm</ng-template>
     <p>
       Prysm is our Ethereum 2.0 client and it comes in two components.
@@ -90,11 +90,20 @@ git clone https://github.com/prysmaticlabs/prysm && cd ./prysm
     <form [formGroup]="depositDataFormGroup">
       <ng-template matStepLabel>Generate a validator public / private key</ng-template>
       <div>
-        <pre>
-   ./prysm.sh validator accounts create --keystore-path=$HOME/validator --password=changeme</pre>
-       <div>
-         From those results, copy and paste the deposit data below.
-       </div>
+        <div [ngSwitch]="hasPrysm">
+          <a *ngSwitchCase="'dappnode'"
+            href="http://my.dappnode/#/packages/prysm-validator.public.dappnode.eth/file-manager?from=%2Fdata%2Fdeposit_data.txt"
+            rel="noopener noreferrer" target="_blank"
+          >
+            Download deposit data
+          </a>
+          <pre *ngSwitchDefault>
+            ./prysm.sh validator accounts create --keystore-path=$HOME/validator --password=changeme
+          </pre>
+        </div>
+        <p>
+          From those results, copy and paste the deposit data below.
+        </p>
        <mat-form-field class="full-width">
          <textarea matInput
                    placeholder="Your validator deposit data"
@@ -115,7 +124,7 @@ git clone https://github.com/prysmaticlabs/prysm && cd ./prysm
     </form>
   </mat-step>
 
-  <mat-step>
+  <mat-step *ngIf="!hasPrysm">
     <ng-template matStepLabel>Start your beacon chain & validator clients</ng-template>
     <span>You'll need two terminals for this step.</span>
     <pre>

--- a/src/app/pages/participate/participate.component.ts
+++ b/src/app/pages/participate/participate.component.ts
@@ -39,6 +39,7 @@ export class ParticipateComponent implements OnInit {
   deposited: boolean | 'pending' = false;
   depositContractAddress: string;
   validatorStatus: ValidatorStatusUpdate;
+  hasPrysm: string;
   readonly MIN_BALANCE = ethers.utils.formatEther(environment.depositAmount);
   readonly DOCKER_TAG = 'latest';
 
@@ -76,6 +77,7 @@ export class ParticipateComponent implements OnInit {
       });
 
     });
+    this.hasPrysm = new URLSearchParams(window.location.search).get('node');
   }
 
   hasMinimumBalance(): boolean {


### PR DESCRIPTION
With a URL parameter skip participate steps regarding installing and running the Prysm client. This is very useful for DAppNode users who we know for sure will already have Prysm installed and running, improving UX.

![Screenshot from 2020-04-15 14-56-05](https://user-images.githubusercontent.com/35266934/79339891-dad4fe80-7f29-11ea-9028-1464815ce766.png)


Additionally, the step to get the deposit data is customized depending on the `node` URL parameter. 

https://prylabs.net/participate?node=dappnode

In case it has de `'dappnode'` value, the URL will be shown a link to directly download the deposit data instead of the command to get it.

![Screenshot from 2020-04-15 14-59-51](https://user-images.githubusercontent.com/35266934/79339884-d90b3b00-7f29-11ea-8233-2fc464624f28.png)
