### PR TITLE
Recommend Users Manually Input Password for Validator

### DIFF
--- a/src/app/pages/participate/participate.component.html
+++ b/src/app/pages/participate/participate.component.html
@@ -98,7 +98,7 @@ git clone https://github.com/prysmaticlabs/prysm && cd ./prysm
             Download deposit data
           </a>
           <pre *ngSwitchDefault>
-            ./prysm.sh validator accounts create --keystore-path=$HOME/validator --password=changeme
+            ./prysm.sh validator accounts create --keystore-path=$HOME/validator
           </pre>
         </div>
         <p>
@@ -133,7 +133,7 @@ git clone https://github.com/prysmaticlabs/prysm && cd ./prysm
 
     <span>Run the next command in another terminal.</span>
     <pre>
-      ./prysm.sh validator --password=changeme --keystore-path=$HOME/validator
+      ./prysm.sh validator --keystore-path=$HOME/validator
   </pre>
   </mat-step>
 


### PR DESCRIPTION
This resolves https://github.com/prysmaticlabs/prysm/issues/5434, currently we recommend users to run the validator command with a `--password=changeme` flag which is stored in terminal history and can be a security hole