### PR TITLE
removes --keystore-path flag

### DIFF
--- a/src/app/pages/participate/participate.component.html
+++ b/src/app/pages/participate/participate.component.html
@@ -98,7 +98,7 @@ git clone https://github.com/prysmaticlabs/prysm && cd ./prysm
             Download deposit data
           </a>
           <pre *ngSwitchDefault>
-            ./prysm.sh validator accounts create --keystore-path=$HOME/validator
+            ./prysm.sh validator accounts create
           </pre>
         </div>
         <p>
@@ -133,7 +133,7 @@ git clone https://github.com/prysmaticlabs/prysm && cd ./prysm
 
     <span>Run the next command in another terminal.</span>
     <pre>
-      ./prysm.sh validator --keystore-path=$HOME/validator
+      ./prysm.sh validator
   </pre>
   </mat-step>
 
@@ -155,7 +155,7 @@ git clone https://github.com/prysmaticlabs/prysm && cd ./prysm
   <mat-step>
     <ng-template matStepLabel>Wait for your validator assignment</ng-template>
     <div>
-      Now, once your validator is up and running - you just have to wait for its activation! This process takes about 2 hours. 
+      Now, once your validator is up and running - you just have to wait for its activation! This process takes about 2 hours.
       You can follow the current beacon chain in Bitfly's block explorer: <a href="https://beaconcha.in" target="_blank">https://beaconcha.in</a> or on <a href="https://beacon.etherscan.io" target="_blank">https://beacon.etherscan.io</a>. Additionally, we recommend registering your node on <a href="https://eth2stats.io" target="_blank">eth2stats</a>.
       <br/>Once you get assigned,
       you'll be able to see how your validator performs its responsibility of creating or voting on blocks as well as earning any rewards throughout its lifecycle.


### PR DESCRIPTION
See: https://github.com/prysmaticlabs/prysm/pull/5592

This PR rationale:
- Keystore manager uses different folders on different OSes, and it is easier to just provide sane defaults
- Now, after above PR is merged, account creation and node running will be relying on the same default values for keystore path. And it will be easier for end-user if we do not require manual path setting.