### PR TITLE
Disable Linear Progression of Steps

### DIFF
--- a/src/app/pages/participate/participate.component.html
+++ b/src/app/pages/participate/participate.component.html
@@ -17,7 +17,7 @@
   </p>
 
 </div>
-<mat-vertical-stepper linear="true" #stepper>
+<mat-vertical-stepper linear="false" #stepper>
   <ng-template matStepperIcon="edit">
     <mat-icon>check</mat-icon>
   </ng-template>


### PR DESCRIPTION
Many users want to look at the steps of the testnet site but are locked out of viewing certain steps or instructions if they have already received goerli ETH. This PR makes the stepper in the participate page non-linear to allow for progressing at ease.