### PR TITLE
Remove Onyx Testnet

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,7 +6,7 @@ import { ParticipateComponent } from './pages/participate/participate.component'
 
 const routes: Routes = [
   {path: '', pathMatch: 'full', component: HomeComponent},
-  {path: 'participate', component: ParticipateComponent},
+  {path: 'participate', component: HomeComponent},
 ];
 
 @NgModule({

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,8 +4,7 @@
 
     <span class="flex-spacer"></span>
     <a class="link" target="_blank" href="https://docs.prylabs.network/docs/getting-started/" mat-button>Read the Docs</a>
-    <a routerLink="/participate" mat-button>Participate</a>
-    <a class="link" target="_blank" href="https://goerli.etherscan.io/address/{{depositContractAddress}}" *ngIf="numValidators" mat-button>{{numValidators}} validators!</a>
+    <a href="https://medalla.launchpad.ethereum.org/" target="_blank" mat-button>Participate</a>
   </mat-toolbar>
   <mat-progress-bar *ngIf="inProgress" mode="indeterminate" color="primary"></mat-progress-bar>
 </nav>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -4,16 +4,14 @@
 </div>
 
 <div class="main-actions">
-  <a routerLink="/participate" mat-button>Become a Validator</a>
+  <a href="https://medalla.launchpad.ethereum.org/" mat-button target="_blank">Become a Validator</a>
 </div>
 
 <mat-card>
   <mat-card-content>
-    <app-chain-info></app-chain-info>
-    <hr/>
     <p>
-    The <a href="https://medalla.launchpad.ethereum.org/" target="_blank">Medalla Testnet</a> is a public network created by the <a href="https://ethereum.org/en/" target="_blank"></a>. It implements the Ethereum 2.0 Phase 0 protocol for a proof-of-stake blockchain,
-    enabling anyone holding test ETH to join and participate. You can join the test by directly participating in the official Ethereum 2.0 <a href="https://medalla.launchpad.ethereum.org/">launchpad</a>. Our team, Prysmatic Labs, created a client implemnetation for Ethereum 2.0 written in Go, called <a href="https://github.com/prysmaticlabs/prysm" target="_blank">Prysm</a>. 
+    The <a href="https://medalla.launchpad.ethereum.org/" target="_blank">Medalla Testnet</a> is a public network created by the <a href="https://ethereum.org/en/" target="_blank">Ethereum Foundation</a>. It implements the Ethereum 2.0 Phase 0 protocol for a proof-of-stake blockchain,
+    enabling anyone holding test ETH to join and participate. You can join the test by directly participating in the official Ethereum 2.0 <a href="https://medalla.launchpad.ethereum.org/">launchpad</a>. Our team, Prysmatic Labs, created a client implementation for Ethereum 2.0 written in Go, called <a href="https://github.com/prysmaticlabs/prysm" target="_blank">Prysm</a>.
     </p>
 
     <p>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,6 +1,6 @@
 <div class="centered">
-  <h1>The Onyx Testnet</h1>
-  <h3>Ethereum Serenity Phase 0 Test Network</h3>
+  <h1>The Medalla Testnet</h1>
+  <h3>Ethereum 2.0 Phase 0 Test Network</h3>
 </div>
 
 <div class="main-actions">
@@ -12,13 +12,10 @@
     <app-chain-info></app-chain-info>
     <hr/>
     <p>
-    The <b>Onyx Testnet</b> is a public network created by <a href="https://prysmaticlabs.com" target="_blank">Prysmatic Labs</a>. It implements the Ethereum 2.0 Phase 0 protocol for a proof-of-stake blockchain,
-    enabling anyone holding Goerli test ETH to join and participate.
+    The <a href="https://medalla.launchpad.ethereum.org/" target="_blank">Medalla Testnet</a> is a public network created by the <a href="https://ethereum.org/en/" target="_blank"></a>. It implements the Ethereum 2.0 Phase 0 protocol for a proof-of-stake blockchain,
+    enabling anyone holding test ETH to join and participate. You can join the test by directly participating in the official Ethereum 2.0 <a href="https://medalla.launchpad.ethereum.org/">launchpad</a>. Our team, Prysmatic Labs, created a client implemnetation for Ethereum 2.0 written in Go, called <a href="https://github.com/prysmaticlabs/prysm" target="_blank">Prysm</a>. 
     </p>
 
-    <p>
-      <i>This is a highly experimental test network</i> with no security guarantees. The network <b>will have scheduled restarts</b> for improvements and maintenance as we help make eth2 a reality.
-    </p>
     <p>
       <a href="https://docs.prylabs.network" target="_blank">💎 Read the Docs 💎</a>
     </p>
@@ -29,31 +26,6 @@
       <a class="social discord" mat-button href="https://discord.gg/YMVYzv6" target="_blank"><img src="assets/discord.svg"/></a>
       <a class="social github" mat-button href="https://github.com/prysmaticlabs/prysm" target="_blank"><img src="assets/github.svg"/>Github</a>
     </p>
-    <hr/>
-    <h2>Testnet Information</h2>
-    <div class="tables">
-      <div>
-        <h3>What This Is</h3>
-
-        <mat-list>
-          <mat-list-item *ngFor="let prop of testnetProperties">
-            <mat-icon mat-list-icon color="primary">check</mat-icon>
-            {{prop}}
-          </mat-list-item>
-        </mat-list>
-      </div>
-
-      <div>
-        <h3>What This Isn't</h3>
-
-        <mat-list>
-          <mat-list-item *ngFor="let prop of notTestnetProperties">
-            <mat-icon mat-list-icon color="warn">clear</mat-icon>
-            {{prop}}
-          </mat-list-item>
-        </mat-list>
-      </div>
-    </div>
     <hr/>
     <h2>Frequently Asked Questions</h2>
     <h3>What is Prysm?</h3>

--- a/src/index.html
+++ b/src/index.html
@@ -12,7 +12,7 @@
   <meta property="og:title" content="Ethereum 2.0 - Phase 0 Testnet">
   <meta property="og:site_name" content="Prysmatic Labs">
   <meta property="og:url" content="https://prylabs.net">
-  <meta property="og:description" content="The Onyx Testnet is a public network created by Prysmatic Labs. It implements the Ethereum 2.0 Phase 0 protocol for a proof-of-stake blockchain enabling anyone holding Goerli test ETH to join!">
+  <meta property="og:description" content="The Medalla Testnet is a public network for Ethereum 2.0. It implements the Ethereum 2.0 Phase 0 protocol for a proof-of-stake blockchain enabling anyone holding Goerli test ETH to join!">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://prylabs.net/assets/preview0.png">
 </head>


### PR DESCRIPTION
This PR removes support for the Onyx testnet and encourages the user to fully use the eth2 launchpad to join Medalla